### PR TITLE
Removed unnecessary code duplication in CreateHttpHandler() func

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A GoLang implementation of counters.
 
 It provides an object: `counters.CounterBox` and `Counter`, `Min` and `Max` implementation.
 
+Installation:
+
+    $ go get -u github.com/orian/counters
+
 The example usages:
 
     import "github.com/orian/counters"
@@ -12,7 +16,7 @@ The example usages:
     cb := counters.NewCounterBox()
     c := cb.GetCounter("ex")
     c.Increment()
-    c.IncrementBy(2)
+    c.IncrementBy(6)
     c.Value()  // returns 7
     cb.GetCounter("ex").Value()  // Returns 7
 
@@ -26,7 +30,7 @@ One may use subpackage `globals` if want to use a global counters.
 
     c := global.GetCounter("ex")
     c.Increment()
-    c.IncrementBy(2)
+    c.IncrementBy(6)
     c.Value()  // returns 7
     global.GetCounter("ex").Value()  // Returns 7
 

--- a/counter.go
+++ b/counter.go
@@ -5,7 +5,6 @@ package counters
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -86,22 +85,7 @@ func New() Counters {
 
 // CreateHttpHandler creates a simple handler printing values of all counters.
 func (c *CounterBox) CreateHttpHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		c.m.RLock()
-		defer c.m.RUnlock()
-		fmt.Fprintf(w, "Counters %d\n", len(c.counters))
-		for k, v := range c.counters {
-			fmt.Fprintf(w, "%s=%d\n", k, v.Value())
-		}
-		fmt.Fprintf(w, "\nMax values %d\n", len(c.max))
-		for k, v := range c.max {
-			fmt.Fprintf(w, "%s=%d\n", k, v.Value())
-		}
-		fmt.Fprintf(w, "\nMin values %d\n", len(c.min))
-		for k, v := range c.min {
-			fmt.Fprintf(w, "%s=%d\n", k, v.Value())
-		}
-	}
+	return func(w http.ResponseWriter, r *http.Request) { c.WriteTo(w) }
 }
 
 func (c *CounterBox) Get(name string) Counter {

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	cnt "github.com/orian/counters/global"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	cnt "github.com/orian/counters/global"
 )
 
 func main() {


### PR DESCRIPTION
The code duplication in `CreateHttpHandler()` method has been removed. This means: already implemented `WriteTo(w io.Writer)` method has been used for writing to `http.ResponseWriter` in the changed function. Described modification also produces nicer output on the `http.ResponseWriter`.

README has been changed to be more intuitive. I think that these changes are self-explanatory.